### PR TITLE
Add links of pdf files to scientific publications title in technology page.

### DIFF
--- a/technology.html
+++ b/technology.html
@@ -62,7 +62,7 @@
     <p class="Gap--45">A short system description was published at WWW2016 and is available here. </p>
 
     <div class="Document">
-      <a href="#">
+      <a href="https://aurelieherbelot.net/resources/papers/www2016_pears.pdf">
         <h3 class="Document__Title">PeARS: a peer-to-peer agent for reciprocated search - PDF</h3>
       </a>
 
@@ -75,7 +75,7 @@
     <p class="Gap--45">A scientific evaluation of the accuracy of the system, published at the *SEM2016 conference, is downloadable here. Please note that the system has substantially changed since then!  It is better... :)</p>
 
     <div class="Document">
-      <a href="#">
+      <a href="https://aurelieherbelot.net/resources/papers/starsem2016_speakers_in_space.pdf">
         <h3 class="Document__Title">You and me in a vector space: Modelling individual speakers
           with distributional semantics - PDF</h3>
       </a>


### PR DESCRIPTION
There is no valid link available in the `href` attribute for the scientific publications. This commit will add the appropriate links of the publications.